### PR TITLE
GlowingBlocks: only show in the current world

### DIFF
--- a/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
@@ -18,7 +18,6 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import fr.skytasul.glowingentities.GlowingEntities.Packets;
 import io.papermc.paper.event.packet.PlayerChunkLoadEvent;
-import io.papermc.paper.event.packet.PlayerChunkUnloadEvent;
 
 /**
  * An extension of {@link GlowingEntities} to make blocks glow as well!
@@ -208,25 +207,6 @@ public class GlowingBlocks implements Listener {
 					&& location.getBlockZ() >> 4 == event.getChunk().getZ()) {
 				try {
 					blockData.spawn();
-				} catch (ReflectiveOperationException ex) {
-					ex.printStackTrace();
-				}
-			}
-		});
-	}
-
-	@EventHandler
-	public void onPlayerChunkUnload(PlayerChunkUnloadEvent event) {
-		PlayerData playerData = glowing.get(event.getPlayer());
-		if (playerData == null)
-			return;
-
-		playerData.datas.forEach((location, blockData) -> {
-			if (Objects.equals(location.getWorld(), event.getWorld())
-					&& location.getBlockX() >> 4 == event.getChunk().getX()
-					&& location.getBlockZ() >> 4 == event.getChunk().getZ()) {
-				try {
-					blockData.remove();
 				} catch (ReflectiveOperationException ex) {
 					ex.printStackTrace();
 				}

--- a/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
@@ -202,7 +202,8 @@ public class GlowingBlocks implements Listener {
 			return;
 		
 		playerData.datas.forEach((location, blockData) -> {
-			if (location.getBlockX() >> 4 == event.getChunk().getX()
+			if (Objects.equals(location.getWorld(), event.getWorld())
+					&& location.getBlockX() >> 4 == event.getChunk().getX()
 					&& location.getBlockZ() >> 4 == event.getChunk().getZ()) {
 				try {
 					blockData.spawn();

--- a/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import fr.skytasul.glowingentities.GlowingEntities.Packets;
 import io.papermc.paper.event.packet.PlayerChunkLoadEvent;
+import io.papermc.paper.event.packet.PlayerChunkUnloadEvent;
 
 /**
  * An extension of {@link GlowingEntities} to make blocks glow as well!
@@ -207,6 +208,25 @@ public class GlowingBlocks implements Listener {
 					&& location.getBlockZ() >> 4 == event.getChunk().getZ()) {
 				try {
 					blockData.spawn();
+				} catch (ReflectiveOperationException ex) {
+					ex.printStackTrace();
+				}
+			}
+		});
+	}
+
+	@EventHandler
+	public void onPlayerChunkUnload(PlayerChunkUnloadEvent event) {
+		PlayerData playerData = glowing.get(event.getPlayer());
+		if (playerData == null)
+			return;
+
+		playerData.datas.forEach((location, blockData) -> {
+			if (Objects.equals(location.getWorld(), event.getWorld())
+					&& location.getBlockX() >> 4 == event.getChunk().getX()
+					&& location.getBlockZ() >> 4 == event.getChunk().getZ()) {
+				try {
+					blockData.remove();
 				} catch (ReflectiveOperationException ex) {
 					ex.printStackTrace();
 				}


### PR DESCRIPTION
We don't want blocks in different worlds to be shown as they are in the same world.

~~DRAFT as I haven't tested it yet.~~

P/S: I agree that there is a workaround to check if the block is in the same world as the player. I just don't want to do that hassle work in all of my projects.