### PR TITLE
added TAB plugin support for glowing entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,22 @@ The same as before but with the `GlowingBlocks` class :)
 
 > **Warning**
 > The `GlowingBlocks` util can only be used on Paper-based servers, not Bukkit or Spigot ones!
+
+## TAB compatibility fallback (PlaceholderAPI)
+If you use TAB and want a glow-color placeholder fallback, this library now provides `%glowingentities_glowcolor%`.
+
+1. Add `PlaceholderAPI` as a `softdepend` in your plugin.yml.
+2. Register the expansion when PlaceholderAPI is available:
+
+```java
+if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+  new GlowingEntitiesPlaceholderExpansion(plugin, glowingEntities).register();
+}
+```
+
+3. Use `%glowingentities_color%` at the end of TAB `tagprefix` (as required by TAB):
+
+```yml
+_DEFAULT_:
+  tagprefix: 'YOURSTUFFHERE%glowingentities_color%'
+```

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
 			<email>skytasul@gmail.com</email>
 			<url>https://skytasul.fr</url>
 		</developer>
+		<developer>
+			<name>NicDevTV</name>
+			<url>https://github.com/NicDevTV</url>
+		</developer>
 	</developers>
 
 	<scm>
@@ -43,6 +47,10 @@
 		<repository>
 			<id>papermc</id>
 			<url>https://repo.papermc.io/repository/maven-public/</url>
+		</repository>
+		<repository>
+			<id>placeholderapi</id>
+			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 	</repositories>
 
@@ -81,6 +89,13 @@
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
 			<version>24.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>me.clip</groupId>
+			<artifactId>placeholderapi</artifactId>
+			<version>2.11.6</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingBlocks.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author SkytAsul
  */
+@SuppressWarnings("deprecation")
 public class GlowingBlocks implements Listener {
 
 	private final @NotNull GlowingEntities entities;

--- a/src/main/java/fr/skytasul/glowingentities/GlowingEntities.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingEntities.java
@@ -39,10 +39,12 @@ import java.util.logging.Logger;
  *
  * @author SkytAsul
  */
+@SuppressWarnings("deprecation")
 public class GlowingEntities implements Listener {
 
 	protected final @NotNull Plugin plugin;
 	private Map<Player, PlayerData> glowing;
+	private Map<UUID, ChatColor> playerGlowColors;
 	boolean enabled = false;
 
 	private int uid;
@@ -71,6 +73,7 @@ public class GlowingEntities implements Listener {
 
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 		glowing = new HashMap<>();
+		playerGlowColors = new HashMap<>();
 		uid = ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE);
 		enabled = true;
 	}
@@ -95,6 +98,7 @@ public class GlowingEntities implements Listener {
 			}
 		});
 		glowing = null;
+		playerGlowColors = null;
 		uid = 0;
 		enabled = false;
 	}
@@ -107,6 +111,7 @@ public class GlowingEntities implements Listener {
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
 		glowing.remove(event.getPlayer());
+		playerGlowColors.remove(event.getPlayer().getUniqueId());
 	}
 
 	/**
@@ -131,6 +136,14 @@ public class GlowingEntities implements Listener {
 	public void setGlowing(Entity entity, Player receiver, ChatColor color) throws ReflectiveOperationException {
 		String teamID = entity instanceof Player ? entity.getName() : entity.getUniqueId().toString();
 		setGlowing(entity.getEntityId(), teamID, receiver, color, Packets.getEntityFlags(entity));
+
+		if (entity instanceof Player playerEntity) {
+			if (color == null) {
+				playerGlowColors.remove(playerEntity.getUniqueId());
+			} else {
+				playerGlowColors.put(playerEntity.getUniqueId(), color);
+			}
+		}
 	}
 
 	/**
@@ -219,6 +232,25 @@ public class GlowingEntities implements Listener {
 	 */
 	public void unsetGlowing(Entity entity, Player receiver) throws ReflectiveOperationException {
 		unsetGlowing(entity.getEntityId(), receiver);
+		if (entity instanceof Player playerEntity) {
+			playerGlowColors.remove(playerEntity.getUniqueId());
+		}
+	}
+
+	/**
+	 * Returns the PlaceholderAPI value for TAB fallback integration.
+	 * <p>
+	 * This matches the `%glowingentities_glowcolor%` placeholder output and returns a
+	 * legacy color code such as {@code &a}. If no color is currently tracked for this player,
+	 * an empty string is returned.
+	 *
+	 * @param player player to resolve
+	 * @return legacy color code with '&' prefix, or empty string
+	 */
+	public @NotNull String getGlowColorPlaceholder(@NotNull Player player) {
+		ensureEnabled();
+		ChatColor color = playerGlowColors.get(player.getUniqueId());
+		return color == null ? "" : "&" + color.getChar();
 	}
 
 	/**
@@ -791,7 +823,7 @@ public class GlowingEntities implements Listener {
 					for (Iterator iterator = subPackets.iterator(); iterator.hasNext();) {
 						Object packet = iterator.next();
 
-						if (packet.getClass().equals(packetMetadata)) {
+						if (packet.getClass().equals(packetMetadata.getClassInstance())) {
 							int entityID = packetMetadataEntity.getInt(packet);
 							GlowingData glowingData = playerData.glowingDatas.get(entityID);
 							if (glowingData != null) {

--- a/src/main/java/fr/skytasul/glowingentities/GlowingEntitiesPlaceholderExpansion.java
+++ b/src/main/java/fr/skytasul/glowingentities/GlowingEntitiesPlaceholderExpansion.java
@@ -1,0 +1,55 @@
+package fr.skytasul.glowingentities;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * PlaceholderAPI expansion for TAB compatibility fallback.
+ * <p>
+ * Exposes `%glowingentities_glowcolor%` as legacy color code (for example {@code &c}).
+ */
+public class GlowingEntitiesPlaceholderExpansion extends PlaceholderExpansion {
+
+	private final @NotNull Plugin plugin;
+	private final @NotNull GlowingEntities glowingEntities;
+
+	public GlowingEntitiesPlaceholderExpansion(@NotNull Plugin plugin, @NotNull GlowingEntities glowingEntities) {
+		this.plugin = plugin;
+		this.glowingEntities = glowingEntities;
+	}
+
+	@Override
+	public @NotNull String getIdentifier() {
+		return "glowingentities";
+	}
+
+	@Override
+	public @NotNull String getAuthor() {
+		return "NicDevTV";
+	}
+
+	@Override
+	public @NotNull String getVersion() {
+		return plugin.getPluginMeta().getVersion();
+	}
+
+	@Override
+	public boolean persist() {
+		return true;
+	}
+
+	@Override
+	public @Nullable String onPlaceholderRequest(Player player, @NotNull String params) {
+		if (player == null)
+			return "";
+
+		if (params.equalsIgnoreCase("color"))
+			return glowingEntities.getGlowColorPlaceholder(player);
+
+		return null;
+	}
+
+}


### PR DESCRIPTION
This pull request adds TAB plugin support for glowing entities.

The implementation is based on TAB’s official compatibility guidance for glow plugins:
https://github.com/NEZNAMY/TAB/wiki/How-to-make-TAB-compatible-with-glow-plugins

What was done

 - Integrated compatibility logic so glowing entities work correctly alongside TAB.
 - Applied the TAB-recommended approach to avoid conflicts with TAB features.
 - Ensured existing glowing behavior remains consistent while TAB is not installed.